### PR TITLE
fix for #2 (Pagination display when there are lots of records)

### DIFF
--- a/django_admin_bootstrapped/templates/admin/pagination.html
+++ b/django_admin_bootstrapped/templates/admin/pagination.html
@@ -9,7 +9,11 @@
         <div class="pagination pagination-small pagination-centered">
             <ul>
             {% for i in page_range %}
-                <li>{% paginator_number cl i %}</li>
+                {% if i == "." %}
+                    <li><span>{% paginator_number cl i %}</span></li>
+                {% else %}
+                    <li>{% paginator_number cl i %}</li>
+                {% endif %}
             {% endfor %}
             </ul>
             <p>


### PR DESCRIPTION
the pagination layout breaks when there are a lot of pages and an ellipsis is added.

adding a span around the ellipsis fixes the issue.

[screenshot of the issue](http://imgur.com/r4RWH)
[screenshot of what it looks like fixed](http://imgur.com/cadeP)
