### PR TITLE
base.html messagelist wrapper

### DIFF
--- a/django_admin_bootstrapped/templates/admin/base.html
+++ b/django_admin_bootstrapped/templates/admin/base.html
@@ -189,9 +189,14 @@ legend a:hover {
 
     {% block messages %}
         {% if messages %}
-        <ul class="messagelist">{% for message in messages %}
-          <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
-        {% endfor %}</ul>
+            <div class="alert alert-block">
+              <button type="button" class="close" data-dismiss="alert">×</button>
+                <ul class="messagelist">
+                    {% for message in messages %}
+                        <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
+                    {% endfor %}
+                </ul>
+            </div>
         {% endif %}
     {% endblock messages %}
 


### PR DESCRIPTION
My first-ever pull request, so please let me know if I'm doing this wrong.

Wrapped the messagelist ul in the base admin template with Bootstrap's "alert" div
