### PR TITLE
Fixed a bug with finding a template

### DIFF
--- a/django_admin_bootstrapped/templatetags/bootstrapped_goodies_tags.py
+++ b/django_admin_bootstrapped/templatetags/bootstrapped_goodies_tags.py
@@ -9,6 +9,6 @@ def render_with_template_if_exist(context, template, fallback):
     text = fallback
     try:
         text = render_to_string(template, context)
-    except TemplateDoesNotExist:
+    except:
         pass
     return text


### PR DESCRIPTION
In languages where app labels can become unicode, loading of the template can fail with UnicodeEncodeError. To prevent all failures with this tag, I removed the specific exception so every exception gets caught and the fallback gets used.

(See base_site.html, line 4)
