### PR TITLE
Feature/sortable inlines

### DIFF
--- a/django_admin_bootstrapped/admin/models.py
+++ b/django_admin_bootstrapped/admin/models.py
@@ -1,0 +1,10 @@
+class SortableInline:
+    sortable_field_name = "position"
+    class Media:
+        js = (
+            '/static/admin/js/jquery.sortable.js',
+        )
+
+        css = {
+            'all':('/static/admin/css/admin-inlines.css',)
+        }

--- a/django_admin_bootstrapped/static/admin/css/admin-inlines.css
+++ b/django_admin_bootstrapped/static/admin/css/admin-inlines.css
@@ -1,0 +1,2 @@
+.sortable-placeholder {border: 1px dashed #ccc;}
+.drag-handler {margin-right:5px;}

--- a/django_admin_bootstrapped/static/admin/js/jquery.sortable.js
+++ b/django_admin_bootstrapped/static/admin/js/jquery.sortable.js
@@ -25,7 +25,7 @@ $.fn.sortable = function(options) {
         var placeholder;
 
         if (/^tbody$/i.test(this.tagName))
-            placeholder = $("<tr class'sortable-placeholder'>").append("<td colspan='100%'></td>");
+            placeholder = $("<tr class='sortable-placeholder'>").append($('<td colspan="100%"'));
         else
             placeholder = $('<' + (/^ul|ol$/i.test(this.tagName) ? 'li' : 'div') + ' class="sortable-placeholder">').html("&nbsp;");
 

--- a/django_admin_bootstrapped/templates/admin/base.html
+++ b/django_admin_bootstrapped/templates/admin/base.html
@@ -12,7 +12,6 @@
 <script type="text/javascript">window.__admin_media_prefix__ = "{% filter escapejs %}{% static "admin/" %}{% endfilter %}";</script>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
 <script src="{% static "bootstrap/js/bootstrap.min.js" %}"></script>
-<script src="{% static "js/jquery.sortable.js" %}"</script>
 
 {% block extrahead %}{% endblock %}
 

--- a/django_admin_bootstrapped/templates/admin/edit_inline/stacked.html
+++ b/django_admin_bootstrapped/templates/admin/edit_inline/stacked.html
@@ -1,9 +1,4 @@
 {% load i18n admin_static %}
-<style type="text/css">
-.sortable-placeholder {
-    border: 1px dashed #ccc;
-}
-</style>
 <div class="_inline-group" id="{{ inline_admin_formset.formset.prefix }}-group">
   <h2>{{ inline_admin_formset.opts.verbose_name_plural|title }}</h2>
 {{ inline_admin_formset.formset.management_form }}

--- a/django_admin_bootstrapped/templates/admin/edit_inline/tabular.html
+++ b/django_admin_bootstrapped/templates/admin/edit_inline/tabular.html
@@ -1,7 +1,4 @@
 {% load i18n admin_static admin_modify %}
-<style>
-  .drag-handler {margin-right:5px;}
-</style>
 <div class="_inline-group" id="{{ inline_admin_formset.formset.prefix }}-group">
   <div class="tabular inline-related {% if forloop.last %}last-related{% endif %}">
 {{ inline_admin_formset.formset.management_form }}


### PR DESCRIPTION
This feature adds drag and drop sortable inlines. To utilize this feature a model must have a position field such as the following.
`position = models.PositiveSmallIntegerField("Position")`

The admin for such a model is as follows.

```
class MySortableInline(admin.TabularInline):
    model = MySortableModel
    extra = 1

    sortable_field_name = "position"
```

The `jquery.sortable.js` file is 3k uncompressed, and could probably be minified down to 1k. A custom jQuery UI build with only the sortable plugin comes in at about 40k.

If this implementation is acceptable I can update the README with documentation about this feature.
