### PR TITLE
Make stacked inlines collapsed by default. 

### DIFF
--- a/django_admin_bootstrapped/admin/models.py
+++ b/django_admin_bootstrapped/admin/models.py
@@ -1,6 +1,5 @@
 class SortableInline:
     sortable_field_name = "position"
-    collapse_stacked = True
 
     class Media:
         js = (
@@ -10,3 +9,6 @@ class SortableInline:
         css = {
             'all':('/static/admin/css/admin-inlines.css',)
         }
+
+class CollapsibleInline:
+    start_collapsed = False

--- a/django_admin_bootstrapped/templates/admin/edit_inline/stacked.html
+++ b/django_admin_bootstrapped/templates/admin/edit_inline/stacked.html
@@ -25,7 +25,7 @@
             </div>
           </legend>
 
-          <div class="{% if not forloop.last %}collapse{% endif %}{% if not inline_admin_formset.opts.collapse_stacked %} in{% endif %}">
+          <div class="{% if not forloop.last %}collapse{% endif %}{% if not inline_admin_formset.opts.start_collapsed %} in{% endif %}">
           {% if inline_admin_form.form.non_field_errors %}{{ inline_admin_form.form.non_field_errors }}{% endif %}
           {% for fieldset in inline_admin_form %}
             {% include "admin/includes/fieldset.html" %}


### PR DESCRIPTION
This pull request adds collapse_stacked option to the SortableInline mixin. It is defaulted to True to allow for a better user experience when utilizing the SortableInline functionality. To disable the auto collapse, add collapse_stacked = False to the admin.StackedInline that uses the SortableInline mixin.
