### PR TITLE
Fix readonly fields alignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 *.pyo
 .DS_Store
+*.egg-info

--- a/django_admin_bootstrapped/templates/admin/base.html
+++ b/django_admin_bootstrapped/templates/admin/base.html
@@ -101,6 +101,9 @@ body {
     -moz-box-sizing: border-box;    /* Firefox, other Gecko */
     box-sizing: border-box;         /* Opera/IE 8+ */
 }
+.controls > p {
+    padding-top: 5px;
+}
 .selector .selector-filter label {
     display: none;
 }


### PR DESCRIPTION
When you have a read-only field in a change form, the value of the field is not properly aligned with the label.

This adds the top padding to fix this issue.
