### PR TITLE
Add conditional for user.has_usable_password

### DIFF
--- a/django_admin_bootstrapped/templates/admin/base.html
+++ b/django_admin_bootstrapped/templates/admin/base.html
@@ -165,7 +165,9 @@ legend a:hover {
                 {% if docsroot %}
                     <li><a href="{{ docsroot }}">{% trans 'Documentation' %}</a></li>
                 {% endif %}
-                <li><a href="{% url 'admin:password_change' %}">{% trans 'Change password' %}</a></li>
+                {% if user.has_usable_password %}
+                    <li><a href="{% url 'admin:password_change' %}">{% trans 'Change password' %}</a></li>
+                {% endif %}
                 <li><a href="{% url 'admin:logout' %}">{% trans 'Log out' %}</a></li>
             {% endblock %}
             {% endif %}


### PR DESCRIPTION
This is a flag set so that if admin package is using a different backend for authentication, that the "change password" url does not show. I'm coping this functionality from: https://code.djangoproject.com/ticket/17967#no1
