### PR TITLE
JS and CSS media paths must be relative

### DIFF
--- a/django_admin_bootstrapped/admin/models.py
+++ b/django_admin_bootstrapped/admin/models.py
@@ -1,14 +1,14 @@
-class SortableInline:
+class SortableInline(object):
     sortable_field_name = "position"
 
     class Media:
         js = (
-            '/static/admin/js/jquery.sortable.js',
+            'admin/js/jquery.sortable.js',
         )
 
         css = {
-            'all':('/static/admin/css/admin-inlines.css',)
+            'all': ('admin/css/admin-inlines.css', )
         }
 
-class CollapsibleInline:
+class CollapsibleInline(object):
     start_collapsed = False


### PR DESCRIPTION
If they are absolute they won't work with a STATIC_URL that has a different domain than the one that the admin interface is hosted on.
