### PR TITLE
Checkbox CSS Class Improvement

### DIFF
--- a/django_admin_bootstrapped/static/admin/css/overrides.css
+++ b/django_admin_bootstrapped/static/admin/css/overrides.css
@@ -28,6 +28,9 @@ a:focus {
     font-size: 100%;
     margin: 0;
 }
+.checkbox{
+    padding-bottom: 5px;
+}
 .checkbox label {
     margin-bottom: -20px;
 }


### PR DESCRIPTION
The css class for the checkbox should be improved.

Boolean fields create a checkbox that needs an adjustment of either padding or margin. As you can see, it comes too close to other fields, and looks off.

![image](https://f.cloud.github.com/assets/595530/718699/48594bde-df6b-11e2-9748-0e20d7eec21e.png)
