### PR TITLE
Display errors properly for inlines

### DIFF
--- a/django_admin_bootstrapped/templates/admin/edit_inline/stacked.html
+++ b/django_admin_bootstrapped/templates/admin/edit_inline/stacked.html
@@ -24,6 +24,13 @@
                 {% if inline_admin_formset.formset.can_delete and inline_admin_form.original %}<div class="delete control-group"><div class="checkbox">{{ inline_admin_form.deletion_field.field }} {{ inline_admin_form.deletion_field.label_tag }}</div></div>{% endif %}
             </div>
           </legend>
+          {% for fieldset in inline_admin_form %}{% for line in fieldset %}
+          {% if line.errors %}
+          {% for field in line %}
+          <div class="alert alert-error"><strong>{{ field.field.label }}:</strong> {{ field.errors|striptags }}</div>
+          {% endfor %}
+          {% endif %}
+          {% endfor %}{% endfor %}
 
           <div class="{% if not forloop.last %}collapse{% endif %}{% if not inline_admin_formset.opts.start_collapsed %} in{% endif %}">
           {% if inline_admin_form.form.non_field_errors %}{{ inline_admin_form.form.non_field_errors }}{% endif %}

--- a/django_admin_bootstrapped/templates/admin/edit_inline/tabular.html
+++ b/django_admin_bootstrapped/templates/admin/edit_inline/tabular.html
@@ -51,7 +51,9 @@
               {% if field.is_readonly %}
                   <p>{{ field.contents }}</p>
               {% else %}
-                  {{ field.field.errors.as_ul }}
+                  {% if field.errors %}
+                  <div class="alert alert-error">{{ field.errors|striptags }}</div>
+                  {% endif %}
                   {{ field.field }}
               {% endif %}
               </td>


### PR DESCRIPTION
With the current code errors for tabular inlines aren't displayed at all, and for stacked inlines they are only visible when expanded. This pull request resolves that.
