### PR TITLE
class typo in fieldset.html for boostrap3

### DIFF
--- a/django_admin_bootstrapped/bootstrap3/templates/admin/includes/fieldset.html
+++ b/django_admin_bootstrapped/bootstrap3/templates/admin/includes/fieldset.html
@@ -24,7 +24,7 @@
                         <div class="control-label col-sm-3">
                             {{ field.label_tag }}
                         </div>
-                        <div class="controls cols-sm-9">
+                        <div class="controls col-sm-9">
                             <div class="checkbox">
                                 {% if field.field.help_text %}{{ field.field.help_text|safe }}{% endif %} {{ field.field }}
                             </div>


### PR DESCRIPTION
was pushing checkboxes in forms to the left
