### PR TITLE
Update change_form.html

### DIFF
--- a/django_admin_bootstrapped/templates/admin/cms/page/change_form.html
+++ b/django_admin_bootstrapped/templates/admin/cms/page/change_form.html
@@ -1,5 +1,5 @@
 {% extends "admin/change_form.html" %}
-{% load i18n admin_modify adminmedia cms_tags cms_admin %}
+{% load i18n admin_modify cms_tags cms_admin %}
 {% load url from future %}
 {% block title %}{% trans "Change a page" %}{% endblock %}
 


### PR DESCRIPTION
Removed adminmedia load as indicated on:

https://docs.djangoproject.com/en/1.5/releases/1.5/#miscellaneous

The template tags library adminmedia, which only contained the deprecated template tag {% admin_media_prefix %}, was removed. Attempting to load it with {% load adminmedia %} will fail. If your templates still contain that line you must remove it.
