### PR TITLE
Update change_list.html

### DIFF
--- a/django_admin_bootstrapped/templates/admin/cms/page/change_list.html
+++ b/django_admin_bootstrapped/templates/admin/cms/page/change_list.html
@@ -1,5 +1,5 @@
 {% extends "admin/change_list.html" %}
-{% load adminmedia admin_list i18n cms_admin cms_js_tags %}
+{% load admin_list i18n cms_admin cms_js_tags %}
 {% block title %}{% trans "List of pages" %}{% endblock %}
 {% block bodyclass %}change-list{% endblock %}
 


### PR DESCRIPTION
The template tags library adminmedia, which only contained the deprecated template tag {% admin_media_prefix %}, was removed. Attempting to load it with {% load adminmedia %} will fail. If your templates still contain that line you must remove it.
https://docs.djangoproject.com/en/1.5/releases/1.5/#miscellaneous
