### PR TITLE
Update menu_item.html

### DIFF
--- a/django_admin_bootstrapped/templates/admin/cms/page/menu_item.html
+++ b/django_admin_bootstrapped/templates/admin/cms/page/menu_item.html
@@ -1,4 +1,4 @@
-{% load cms_admin i18n adminmedia %}
+{% load cms_admin i18n  %}
 <div class="cont{% if CMS_MODERATOR %} moderatorstate{{ page_moderator_state.state }}{% endif %}">
 	<div class="col1">
 		{% if has_change_permission %}


### PR DESCRIPTION
The template tags library adminmedia, which only contained the deprecated template tag {% admin_media_prefix %}, was removed. Attempting to load it with {% load adminmedia %} will fail. If your templates still contain that line you must remove it.
https://docs.djangoproject.com/en/1.5/releases/1.5/#miscellaneous
