### PR TITLE
Display bug for top admin actions

### DIFF
--- a/django_admin_bootstrapped/bootstrap3/static/admin/css/overrides.css
+++ b/django_admin_bootstrapped/bootstrap3/static/admin/css/overrides.css
@@ -64,3 +64,5 @@ td.action-checkbox {
 }
 
 .tooltip.in {opacity: 1} /* Hard to see against black text otherwise */
+
+#result_list {clear: both;}


### PR DESCRIPTION
When viewed on Firefox, the previous re-implementation of the actions-on-top box was overlaid on the main table.  Applying "clear: both" to the table corrects the issue.
