### PR TITLE
fix displaying of username for custom user model

### DIFF
--- a/django_admin_bootstrapped/bootstrap3/templates/admin/base.html
+++ b/django_admin_bootstrapped/bootstrap3/templates/admin/base.html
@@ -66,7 +66,7 @@
                     <ul class="nav navbar-nav">
                         {% if user.is_active and user.is_staff %}
                         <li class="dropdown">
-                            <a href="#" class="dropdown-toggle" data-toggle="dropdown">{% trans 'Welcome,' %} <strong>{% filter force_escape %}{% firstof user.first_name user.username %}{% endfilter %}</strong> <span class="caret"></span></a>
+                            <a href="#" class="dropdown-toggle" data-toggle="dropdown">{% trans 'Welcome,' %} <strong>{% filter force_escape %}{% firstof user.get_short_name user.get_username user.first_name user.username %}{% endfilter %}</strong> <span class="caret"></span></a>
                             <ul class="dropdown-menu">
                                 {% if user.has_usable_password %}
                                 <li><a href="{% url 'admin:password_change' %}">{% trans 'Change password' %}</a></li>

--- a/django_admin_bootstrapped/templates/admin/base.html
+++ b/django_admin_bootstrapped/templates/admin/base.html
@@ -64,7 +64,7 @@
                     <ul class="nav">
                         {% if user.is_active and user.is_staff %}
                         <li class="dropdown">
-                            <a href="#" class="dropdown-toggle" data-toggle="dropdown">{% trans 'Welcome,' %} <strong>{% filter force_escape %}{% firstof user.first_name user.username %}{% endfilter %}</strong> <b class="caret"></b></a>
+                            <a href="#" class="dropdown-toggle" data-toggle="dropdown">{% trans 'Welcome,' %} <strong>{% filter force_escape %}{% firstof user.get_short_name user.get_username user.first_name user.username %}{% endfilter %}</strong> <b class="caret"></b></a>
                             <ul class="dropdown-menu pull-right">
                                 {% if user.has_usable_password %}
                                 <li><a href="{% url 'admin:password_change' %}">{% trans 'Change password' %}</a></li>


### PR DESCRIPTION
Added a fix for displaying correctly either short name or user name if user model was redefined as described in Django documentation:
https://docs.djangoproject.com/en/1.6/topics/auth/customizing/

Custom user model may not have `first_name` and `username` defined. Those values should be retrieved using `get_short_name` and `get_username` respectively.
