### PR TITLE
Fixed classes for error labels (both field and general) in bootstrap3

### DIFF
--- a/django_admin_bootstrapped/bootstrap3/templates/admin/change_form.html
+++ b/django_admin_bootstrapped/bootstrap3/templates/admin/change_form.html
@@ -47,7 +47,7 @@
 <form class="form-horizontal" {% if has_file_field %}enctype="multipart/form-data" {% endif %}action="{{ form_url }}" method="post" id="{{ opts.module_name }}_form">{% csrf_token %}{% block form_top %}{% endblock %}
     <div class="alert alert-warning">{% blocktrans %}Fields in <strong>bold</strong> are required.{% endblocktrans %}</div>
     {% if errors %}
-    <div class="alert alert-error">
+    <div class="alert alert-danger">
         {% blocktrans count counter=errors|length %}Please correct the error below.{% plural %}Please correct the errors below.{% endblocktrans %}
         {{ adminform.form.non_field_errors }}
     </div>

--- a/django_admin_bootstrapped/bootstrap3/templates/admin/includes/fieldset.html
+++ b/django_admin_bootstrapped/bootstrap3/templates/admin/includes/fieldset.html
@@ -39,7 +39,7 @@
                             {% else %}
                                 {{ field.field }}
                             {% endif %}
-                            {% if not field.is_readonly and field.errors %}<span class="help-inline">{{ field.errors|striptags }}</span>{% endif %}
+                            {% if not field.is_readonly and field.errors %}<span class="label label-danger">{{ field.errors|striptags }}</span>{% endif %}
                             {% if field.field.help_text %}
                                 <span class="help-block">{{ field.field.help_text|safe }}</span>
                             {% endif %}


### PR DESCRIPTION
Got some user comments that the warnings weren't very visible.  I fixed the non-existent `alert-error` class in the general errors and add `label` and `label-danger` to the individual field errors.
