### PR TITLE
Fix application label in breadcrumbs (change form)

### DIFF
--- a/django_admin_bootstrapped/bootstrap3/templates/admin/change_form.html
+++ b/django_admin_bootstrapped/bootstrap3/templates/admin/change_form.html
@@ -17,7 +17,7 @@
 {% block breadcrumbs %}
 <ul class="breadcrumb">
 <li><a href="{% url 'admin:index' %}">{% trans 'Home' %}</a></li>
-<li><a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ app_label|capfirst|escape }}</a></li>
+<li><a href="{% url 'admin:app_list' app_label=opts.app_label %}">{% with app_label=opts.app_config.verbose_name|default:opts.app_label %}{{ app_label|title }}{% endwith %}</a></li>
 <li>{% if has_change_permission %}<a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>{% else %}{{ opts.verbose_name_plural|capfirst }}{% endif %}</li>
 <li>{% if add %}{% trans 'Add' %} {{ opts.verbose_name }}{% else %}{{ original|truncatewords:"18" }}{% endif %}</li>
 </ul>


### PR DESCRIPTION
The change_form.html did not display the same label for the application
as the change_list.html.
