### PR TITLE
Fix hidden display of actions links in change_list

### DIFF
--- a/django_admin_bootstrapped/bootstrap3/static/admin/css/changelists.css
+++ b/django_admin_bootstrapped/bootstrap3/static/admin/css/changelists.css
@@ -1,0 +1,16 @@
+/* CHANGELISTS */
+
+.change-list .hiddenfields { display:none; }
+
+/* ACTIONS */
+
+.actions span.all,
+.actions span.action-counter,
+.actions span.clear,
+.actions span.question {
+    display: none;
+}
+
+#action-toggle {
+    display: none;
+}


### PR DESCRIPTION
The js for the action feedback and multiple selection links assumes
some spans have a initial hidden display.

The sheet admin/css/changelists.css seems not being used at all.
We override it with the relevant parts and everything else with
"display: none".
