### PR TITLE
Create new templates tags

### DIFF
--- a/django_admin_bootstrapped/templatetags/bootstrapped_goodies_tags.py
+++ b/django_admin_bootstrapped/templatetags/bootstrapped_goodies_tags.py
@@ -59,9 +59,11 @@ def render_name(context, app, template="/admin_app_name.html", fallback="Applica
     """
     text = fallback
     try:
-        # build template path as app_label/template_name
-        template = app['app_label'] + template
-        text = render_to_string(template, context)
+        try:
+            template = app['app_label'] + template
+            text = render_to_string(template, context)
+        except:
+            text = app['name']
     except:
         pass
     return text


### PR DESCRIPTION
New tags :
- render_name
- render_label
- render_description

This should replace the entries likes :
- {% render_with_template_if_exist
  app.name|lower|add:"/admin_app_name.html" app.name %}
  by
- {% render_name app%}
