### PR TITLE
Adjust form label size

### DIFF
--- a/django_admin_bootstrapped/bootstrap3/static/admin/css/overrides.css
+++ b/django_admin_bootstrapped/bootstrap3/static/admin/css/overrides.css
@@ -108,3 +108,8 @@ td.action-checkbox {
     margin-left: 0px;
     margin-right: 5px;
 }
+
+/* admin/css/forms.css makes labels too small */
+.control-label label {
+    font-size: 14px;
+}


### PR DESCRIPTION
The sheet admin/css/forms.css makes labels too small
so we replace the original bootstrap size.
