### PR TITLE
- wrapped max() and division calls to solve problems with empty objects

### DIFF
--- a/django_admin_bootstrapped/templatetags/bootstrapped_goodies_tags.py
+++ b/django_admin_bootstrapped/templatetags/bootstrapped_goodies_tags.py
@@ -36,17 +36,26 @@ def language_selector(context):
 
 @register.filter(name='column_width')
 def column_width(value):
-    return 12 // len(list(value))
+    try:
+        return 12 // len(list(value))
+    except ZeroDivisionError:
+        return 12
 
 @register.filter(name='form_fieldset_column_width')
 def form_fieldset_column_width(form):
     def max_line(fieldset):
         return max([len(list(line)) for line in fieldset])
 
-    width = max([max_line(fieldset) for fieldset in form])
-    return 12 // width
+    try:
+        width = max([max_line(fieldset) for fieldset in form])
+        return 12 // width
+    except ValueError:
+        return 12
 
 @register.filter(name='fieldset_column_width')
 def fieldset_column_width(fieldset):
-    width = max([len(list(line)) for line in fieldset])
-    return 12 // width
+    try:
+        width = max([len(list(line)) for line in fieldset])
+        return 12 // width
+    except ValueError:
+        return 12


### PR DESCRIPTION
I was messing around with some placeholder objects and was getting exceptions because they didn't have any visible fields.  Probably a rather unusual problem, but a simple enough fix so I thought I'd send it along.  
