### PR TITLE
Create new templates tags [Cleaned]

### DIFF
--- a/django_admin_bootstrapped/bootstrap3/templates/admin/app_index.html
+++ b/django_admin_bootstrapped/bootstrap3/templates/admin/app_index.html
@@ -6,7 +6,7 @@
 <ul class="breadcrumb">
 <li><a href="{% url 'admin:index' %}">{% trans 'Home' %}</a></li>
 {% for app in app_list %}
-<li>{% render_name app %}</li>
+<li>{% render_app_name app %}</li>
 {% endfor %}
 </ul>
 {% endblock %}
@@ -14,7 +14,7 @@
 
 {% block content_title %}
 {% for app in app_list %}
-<a class="navbar-brand">{% render_name app %} {% trans "administration" %}</a>
+<a class="navbar-brand">{% render_app_name app %} {% trans "administration" %}</a>
 {% endfor %}
 {% endblock %}
 

--- a/django_admin_bootstrapped/bootstrap3/templates/admin/bootstrapped_extra/app_name.html
+++ b/django_admin_bootstrapped/bootstrap3/templates/admin/bootstrapped_extra/app_name.html
@@ -1,2 +1,2 @@
 {% load i18n admin_static bootstrapped_goodies_tags %}
-<h2 id='{% render_label app %}' class="app-name"><a href="{{ app.app_url }}">{% render_name app %}</a></h2>
+<h2 id='{% render_app_label app %}' class="app-name"><a href="{{ app.app_url }}">{% render_app_name app %}</a></h2>

--- a/django_admin_bootstrapped/bootstrap3/templates/admin/index.html
+++ b/django_admin_bootstrapped/bootstrap3/templates/admin/index.html
@@ -20,7 +20,7 @@
         <ul class="dropdown-menu" role="menu">
             {% for app in app_list %}
             <li>
-                <a href="#"><strong>{% render_name app %}</strong></a>
+                <a href="#"><strong>{% render_app_name app %}</strong></a>
             </li>
             {% for model in app.models %}
             <li>
@@ -48,7 +48,7 @@
         <div class="tabbable">
             {% for app in app_list %}
                 {% include "admin/bootstrapped_extra/app_name.html" %}
-                {% render_description app fallback="" %}
+                {% render_app_description app %}
                 <table summary="{% blocktrans with name=app.name %}Models available in the {{ name }} application.{% endblocktrans %}" class="table table-striped table-bordered">
                 {% for model in app.models %}
                     <tr>

--- a/django_admin_bootstrapped/templatetags/bootstrapped_goodies_tags.py
+++ b/django_admin_bootstrapped/templatetags/bootstrapped_goodies_tags.py
@@ -53,24 +53,21 @@ def fieldset_column_width(fieldset):
 
 
 @register.simple_tag(takes_context=True)
-def render_name(context, app, template="/admin_app_name.html", fallback="Application name"):
+def render_app_name(context, app, template="/admin_app_name.html"):
     """ Render the application name using the default template name. If it cannot find a
         template matching the given path, fallback to the application name.
     """
-    text = fallback
+    text = None
     try:
-        try:
-            template = app['app_label'] + template
-            text = render_to_string(template, context)
-        except:
-            text = app['name']
+        template = app['app_label'] + template
+        text = render_to_string(template, context)
     except:
-        pass
+        text = app['name']
     return text
 
 
 @register.simple_tag(takes_context=True)
-def render_label(context, app, fallback="Application label"):
+def render_app_label(context, app, fallback=""):
     """ Render the application label.
     """
     text = fallback
@@ -84,7 +81,7 @@ def render_label(context, app, fallback="Application label"):
 
 
 @register.simple_tag(takes_context=True)
-def render_description(context, app, template="/admin_app_description.html", fallback="Application description"):
+def render_app_description(context, app, fallback="", template="/admin_app_description.html"):
     """ Render the application description using the default template name. If it cannot find a
         template matching the given path, fallback to the fallback argument.
     """


### PR DESCRIPTION
New tags :
- render_name
- render_label
- render_description

This should replace the entries likes :
- {% render_with_template_if_exist
  app.name|lower|add:"/admin_app_name.html" app.name %}
  by
- {% render_name app%}
