### PR TITLE
Properly collapse nested fieldsets

### DIFF
--- a/django_admin_bootstrapped/templates/admin/edit_inline/stacked.html
+++ b/django_admin_bootstrapped/templates/admin/edit_inline/stacked.html
@@ -9,7 +9,7 @@
         <div class="well well-small inline-related{% if forloop.last %} empty-form last-related{% endif %}" id="{{ inline_admin_formset.formset.prefix }}-{% if not forloop.last %}{{ forloop.counter0 }}{% else %}empty{% endif %}">
           <legend>
             {% if not forloop.last %}
-            <a data-toggle="collapse" data-target="#{{ inline_admin_formset.formset.prefix }}-{% if not forloop.last %}{{ forloop.counter0 }}{% else %}empty{% endif %} .collapse">
+            <a data-toggle="collapse" data-target="#{{ inline_admin_formset.formset.prefix }}-{% if not forloop.last %}{{ forloop.counter0 }}{% else %}empty{% endif %} > .collapse">
             {% endif %}
             {% if inline_admin_form.original %}{{ inline_admin_form.original }}{% else %}#{{ forloop.counter }}{% endif %} <small class="inline_label">({{ inline_admin_formset.opts.verbose_name }})</small>
             {% if not forloop.last %}
@@ -34,9 +34,9 @@
 
           <div class="{% if not forloop.last %}collapse{% endif %}{% if not inline_admin_formset.opts.start_collapsed %} in{% endif %}">
           {% if inline_admin_form.form.non_field_errors %}{{ inline_admin_form.form.non_field_errors }}{% endif %}
-          {% with stacked_prefix=forloop.counter0 %}
+          {% with stacked_prefix=forloop.counter %}
           {% for fieldset in inline_admin_form %}
-            {% include "admin/includes/fieldset.html" with group_column_width=fieldset|fieldset_column_width %}
+            {% include "admin/includes/fieldset.html" with group_column_width=fieldset|fieldset_column_width stacked_prefix=stacked_prefix %}
           {% endfor %}
           {% endwith %}
           {% if inline_admin_form.has_auto_field or inline_admin_form.needs_explicit_pk_field %}{{ inline_admin_form.pk_field.field }}{% endif %}


### PR DESCRIPTION
I noticed a few things were happening with the collapsing nested fieldsets:
1. The top-most collapse button was targeting all children with `collapse` class.
2. `static_prefix` wasn't being passed to the fieldset template.
3. `{% if static_prefix %}` was evaluating to False on the first loop when using the zero-indexed `forloop.counter0`.

This should fix #129, but I've only tested it with the test models/admin @Talkless provided.
