### PR TITLE
Alert Message Bootstrap Classes

### DIFF
--- a/django_admin_bootstrapped/templates/admin/base.html
+++ b/django_admin_bootstrapped/templates/admin/base.html
@@ -157,7 +157,7 @@
         <div class="row">
             <div class="col-sm-12">
                 {% for message in messages %}
-                <div class="alert alert-info {% if message.tags %}{{ message.tags }}{% endif %}">
+                <div class="alert {{ message.tags|default:'alert-info' }}">
                     {{ message }}
                 </div>
                 {% endfor %}


### PR DESCRIPTION
A small patch  to keep the messages from always showing the `alert-info` class and allow the documented overrides to be used instead. 
