### PR TITLE
bootstrap3.html was moved to bootstrap3.utils

### DIFF
--- a/django_admin_bootstrapped/renderers.py
+++ b/django_admin_bootstrapped/renderers.py
@@ -6,7 +6,7 @@ from django.contrib.admin.widgets import (AdminDateWidget, AdminTimeWidget,
 from django.forms import (FileInput, CheckboxInput, RadioSelect, CheckboxSelectMultiple)
 
 from bootstrap3 import renderers
-from bootstrap3.html import add_css_class
+from bootstrap3.utils import add_css_class
 from bootstrap3.text import text_value
 
 class BootstrapFieldRenderer(renderers.FieldRenderer):


### PR DESCRIPTION
See change: https://github.com/dyve/django-bootstrap3/commit/b54d120ad814fbc730103f369d6f39c44257b1fd