### PR TITLE
Import firstof from future to ensure Django 1.8 compatibility

### DIFF
--- a/django_admin_bootstrapped/templates/admin/base.html
+++ b/django_admin_bootstrapped/templates/admin/base.html
@@ -1,3 +1,4 @@
+{% load firstof from future %}
 {% load admin_static bootstrapped_goodies_tags %}
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="{{ LANGUAGE_CODE|default:"en-us" }}" {% if LANGUAGE_BIDI %}dir="rtl"{% endif %}>


### PR DESCRIPTION
Fixes this warning about the [upcoming changes to the `firstof` template tag](https://docs.djangoproject.com/en/1.7/internals/deprecation/#deprecation-removed-in-1-8)

    RemovedInDjango18Warning: 'The `firstof` template tag is changing to escape its arguments; the non-autoescaping version is deprecated. Load it from the `future` tag library to start using the new behavior.