### PR TITLE
CheckboxSelectMultiple fix for 1.8

### DIFF
--- a/django_admin_bootstrapped/static/admin/css/overrides.css
+++ b/django_admin_bootstrapped/static/admin/css/overrides.css
@@ -10,14 +10,17 @@ a:focus {
 .controls > p {
     padding-top: 5px;
 }
-.controls > ul {
+.controls > ul,
+.controls > .related-widget-wrapper > ul {
     list-style-type: none;
     padding-left: 0px;
 }
-.controls > ul label {
+.controls > ul label,
+.controls > .related-widget-wrapper > ul label {
     font-size: 14px;
 }
-.controls > ul .form-control {
+.controls > ul .form-control,
+.controls > .related-widget-wrapper > ul .form-control {
     height: auto;
     margin: 9px 0;
 }


### PR DESCRIPTION
Django 1.8 adds a div.related-widget-wrapper around checkbox ULs. Allow for this in CSS.