### PR TITLE
Basic Tabpanel for add/change form

### DIFF
--- a/django_admin_bootstrapped/admin/models.py
+++ b/django_admin_bootstrapped/admin/models.py
@@ -1,3 +1,7 @@
+from django.contrib import admin
+from collections import OrderedDict
+import json
+
 class SortableInline(object):
     sortable_field_name = "position"
 
@@ -12,3 +16,55 @@ class SortableInline(object):
 
 class CollapsibleInline(object):
     start_collapsed = False
+
+
+class TabPanelMixin(object):
+    """Adds tabs to add/change form views in ModelAdmin"""
+
+    tabs = ()
+    """List of defined tabs.
+    Each tab is defined by a tuple: ('tab_name', list_of_elements_to_contain)
+    Example:
+    tabs = [('Tab_name', ['fieldset_name', InlineClass]), #Other tabs...]
+    """
+
+    tabs_pos = 'top'
+    """Tabs position ('top', 'left', 'right' or 'bottom')"""
+
+    def _tabs_context(self, extra_context):
+        if self.fieldsets is not None:
+            fsets_order = [x[0] for x in self.fieldsets]
+        else:
+            fsets_order = []
+
+        tabs = OrderedDict()
+        for k in self.tabs:
+            tab_name, tab_content = k
+            tabs[tab_name] = []
+            for v in tab_content:
+                sel = ''
+
+                if (v is None or fsets_order.count(v)):
+                    sel = fsets_order.index(v), 'f'
+                else:
+                    # Inline
+                    sel = self.inlines.index(v), 'i'
+
+                tabs[tab_name].append(sel)
+
+        extra_context = extra_context or {}
+        extra_context['tabs'] = json.dumps(tabs)
+        extra_context['tabs_pos'] = self.tabs_pos
+
+        return extra_context
+
+    def change_view(self, request, object_id, form_url='', extra_context=None):
+        extra_context = self._tabs_context(extra_context)
+        return super(TabPanelMixin, self).change_view(request, object_id,
+                                                      form_url,
+                                                      extra_context=extra_context)
+
+    def add_view(self, request, form_url='', extra_context=None):
+        extra_context = self._tabs_context(extra_context)
+        return super(TabPanelMixin, self).add_view(request, form_url,
+                                                   extra_context=extra_context)

--- a/django_admin_bootstrapped/static/admin/css/admin-tabpanel.css
+++ b/django_admin_bootstrapped/static/admin/css/admin-tabpanel.css
@@ -1,0 +1,116 @@
+/* Taken from http://www.bootply.com/74926# */
+/* custom inclusion of right, left and bottom tabs */
+
+.tabs-bottom > .nav-tabs,
+.tabs-right > .nav-tabs,
+.tabs-left > .nav-tabs {
+  border-bottom: 0;
+}
+
+.tab-content > .tab-pane,
+.pill-content > .pill-pane {
+  display: none;
+}
+
+.tab-content > .active,
+.pill-content > .active {
+  display: block;
+}
+
+.tabs-bottom > .nav-tabs {
+  border-top: 1px solid #ddd;
+}
+
+.tabs-bottom > .nav-tabs > li {
+  margin-top: -1px;
+  margin-bottom: 0;
+}
+
+.tabs-bottom > .nav-tabs > li > a {
+  -webkit-border-radius: 0 0 4px 4px;
+     -moz-border-radius: 0 0 4px 4px;
+          border-radius: 0 0 4px 4px;
+}
+
+.tabs-bottom > .nav-tabs > li > a:hover,
+.tabs-bottom > .nav-tabs > li > a:focus {
+  border-top-color: #ddd;
+  border-bottom-color: transparent;
+}
+
+.tabs-bottom > .nav-tabs > .active > a,
+.tabs-bottom > .nav-tabs > .active > a:hover,
+.tabs-bottom > .nav-tabs > .active > a:focus {
+  border-color: transparent #ddd #ddd #ddd;
+}
+
+.tabs-left > .nav-tabs > li,
+.tabs-right > .nav-tabs > li {
+  float: none;
+}
+
+.tabs-left > .nav-tabs > li > a,
+.tabs-right > .nav-tabs > li > a {
+  min-width: 74px;
+  margin-right: 0;
+  margin-bottom: 3px;
+}
+
+.tabs-left > .nav-tabs {
+  float: left;
+  margin-right: 19px;
+  border-right: 1px solid #ddd;
+}
+
+.tabs-left > .nav-tabs > li > a {
+  margin-right: -1px;
+  -webkit-border-radius: 4px 0 0 4px;
+     -moz-border-radius: 4px 0 0 4px;
+          border-radius: 4px 0 0 4px;
+}
+
+.tabs-left > .nav-tabs > li > a:hover,
+.tabs-left > .nav-tabs > li > a:focus {
+  border-color: #eeeeee #dddddd #eeeeee #eeeeee;
+}
+
+.tabs-left > .nav-tabs .active > a,
+.tabs-left > .nav-tabs .active > a:hover,
+.tabs-left > .nav-tabs .active > a:focus {
+  border-color: #ddd transparent #ddd #ddd;
+  *border-right-color: #ffffff;
+}
+
+.tabs-right > .nav-tabs {
+  float: right;
+  margin-left: 19px;
+  border-left: 1px solid #ddd;
+}
+
+.tabs-right > .nav-tabs > li > a {
+  margin-left: -1px;
+  -webkit-border-radius: 0 4px 4px 0;
+     -moz-border-radius: 0 4px 4px 0;
+          border-radius: 0 4px 4px 0;
+}
+
+.tabs-right > .nav-tabs > li > a:hover,
+.tabs-right > .nav-tabs > li > a:focus {
+  border-color: #eeeeee #eeeeee #eeeeee #dddddd;
+}
+
+.tabs-right > .nav-tabs .active > a,
+.tabs-right > .nav-tabs .active > a:hover,
+.tabs-right > .nav-tabs .active > a:focus {
+  border-color: #ddd #ddd #ddd transparent;
+  *border-left-color: #ffffff;
+}
+
+/*FIXES*/
+
+.tabs-left  > .tab-content , .tabs-right  > .tab-content {
+    overflow: hidden;
+}
+.tab-content {
+    padding-top: 10px;
+}

--- a/django_admin_bootstrapped/static/admin/js/tabpanel.js
+++ b/django_admin_bootstrapped/static/admin/js/tabpanel.js
@@ -1,0 +1,53 @@
+
+/*Creates tabpanel according to tabpanel_data*/
+function create_tabs(tabpanel_data, tabs_pos) {
+
+    keys = Object.keys(tabpanel_data); // tabs names
+    if (keys == 0) {
+        return;
+    }
+    var tab_intern = "<ul class='nav nav-tabs' role='tablist'></ul><div class='tab-content'></div>";
+    if (tabs_pos == 'bottom') {
+        tab_intern = "<div class='tab-content'></div><ul class='nav nav-tabs' role='tablist'></ul>";
+    }
+
+    var newtabs = "<div id='tab-container' class='tabs-" + tabs_pos +
+                  "' role='tabpanel'>"+tab_intern+"</div>" ;
+
+    var main_container = "#content";
+    $(newtabs).insertBefore('#content-main'); // Position for new tabpanel
+
+
+    // Get all fieldsets and inlines
+    var fsets = $(main_container).find("fieldset").not("._inline-group fieldset");
+    var inlines = $(main_container).find("div._inline-group"); 
+
+    for (var i = 0; i <  keys.length; i++) { 
+
+        // Add anchor (tab header)    
+        $("#tab-container ul").append("<li role='presentation'><a role='tab' \
+                                       data-toggle='tab' aria-controls='#tabs-"+ i +
+                                       "' href='#tabs-" + i + "'>"+keys[i]+"</a></li>");
+        // Add tab content
+        $("#tab-container div.tab-content").append("<div role='tabpanel' class='tab-pane fade' id='tabs-"+  i +"'></div>");
+        
+        // Add tab contents (relocate django html: fieldsets, and inline)
+        var entries = tabpanel_data[keys[i]];
+        for (var j=0; j < entries.length; j++){
+            var e = entries[j];
+            var pos = e[0];
+
+            if (e[1] == 'f') {
+                // Fieldset
+                $(fsets[pos]).appendTo("#tabs-" + i); 
+            }
+            else {
+                // Inline
+                $(inlines[pos]).appendTo("#tabs-" + i); 
+            }
+        }
+    }
+
+    $('#tab-container a:first').tab('show');
+
+  }

--- a/django_admin_bootstrapped/templates/admin/base.html
+++ b/django_admin_bootstrapped/templates/admin/base.html
@@ -18,6 +18,7 @@
     </style>
     <link href="{% static "bootstrap/css/bootstrap-theme.min.css" %}" rel="stylesheet"/>
     <link rel="stylesheet" type="text/css" href="{% static "admin/css/overrides.css" %}" />
+    <link rel="stylesheet" type="text/css" href="{% static "admin/css/admin-tabpanel.css" %}" />
 
     <!-- <link rel="stylesheet" type="text/css" href="{% block stylesheet %}{% static "admin/css/base.css" %}{% endblock %}" /> -->
     <script type="text/javascript">
@@ -29,6 +30,7 @@
     <script src="{% static "admin/js/jquery-1.9.1.min.js" %}"></script>
     <script src="{% static "admin/js/jquery-migrate-1.2.1.min.js" %}"></script>
     <script src="{% static "bootstrap/js/bootstrap.min.js" %}"></script>
+    <script src="{% static "admin/js/tabpanel.js" %}"></script>
 
     {% block extrahead %}{% endblock %}
 
@@ -39,6 +41,11 @@
                 $(document).ready(function() {
                     $('input[type="submit"]').addClass('btn');
                     $('[title]').tooltip();
+
+                    {# Tabpanel #}
+                    var tabpanel_data = {{tabs|safe|default_if_none:'{}'}};
+                    var tabs_pos = '{{tabs_pos|safe}}';
+                    create_tabs(tabpanel_data, tabs_pos);
                 });
             }(jQuery));
     //]]>


### PR DESCRIPTION
Hello. This is a feature to add tab panels to add/change forms in the admin using Bootstrap's tab component. Basically after you define your fieldsets and inlines in your ModelAdmin you can define tabs that will contain those elements. I had to do this for a job, hopefully you'll find it useful. 

Example:
Normal add/change view: http://i.imgur.com/4Y1N9H1.png
With tabpanel: http://i.imgur.com/xFGOQKy.png http://i.imgur.com/FmGJdhV.png

The example code is this (just the relevant part):
```python
from django_admin_bootstrapped.admin.models import TabPanelMixin

class BookAdmin(TabPanelMixin, admin.ModelAdmin):

    fieldsets = (
        ("General", {'fields': ('name',),}),
        ("Other" , {'fields': ('author',)}),
    )

    inlines = [PageInline, LabelInline]
    
    tabs = [
            ("General", ("General", PageInline)), 
            ("Other", ("Other",LabelInline)),
            ]
            
admin.site.register(Book, BookAdmin)
```
Cheers.