### PR TITLE
Bootstrapping filter-horizontal and file-upload widgets

### DIFF
--- a/django_admin_bootstrapped/static/admin/css/overrides.css
+++ b/django_admin_bootstrapped/static/admin/css/overrides.css
@@ -247,12 +247,19 @@ td.action-checkbox {
     clear: both;
 }
 
+/* FILE UPLOAD WIDGET*/
+
 p.file-upload {
     line-height: 29px;
     margin: 1;
-    padding: 1;
+    padding: 2px 0px 10px 0px;
     color: #666;
     font-size: inherit;
     font-weight: inherit;
     font-family: inherit;
+}
+
+p.file-upload > input[type="file"] {
+    display: inline;
+    margin-left: 5px;
 }

--- a/django_admin_bootstrapped/static/admin/css/overrides.css
+++ b/django_admin_bootstrapped/static/admin/css/overrides.css
@@ -77,12 +77,6 @@ a:focus {
     transition: border-color 0.15s ease-in-out 0s, box-shadow 0.15s ease-in-out 0s;
 }
 
-
-/* can't resize selector-chosen height, so we'll just move it down to match selector-available*/
-.selector > .selector-chosen > select {
-    margin-top: 13px;
-}
-
 /* selector object list items */
 .selector > .selector-available > select > option, .selector > .selector-chosen > select > option {
     padding: 6px;

--- a/django_admin_bootstrapped/static/admin/css/overrides.css
+++ b/django_admin_bootstrapped/static/admin/css/overrides.css
@@ -81,8 +81,8 @@ a:focus {
 .selector > .selector-available > select > option, .selector > .selector-chosen > select > option {
     padding: 6px;
     border-bottom-width: 1px;
-    border-bottom-color: lightgray;
-    border-bottom-style: groove
+    border-bottom-color: rgba(211, 211, 211, 0.35);
+    border-bottom-style: solid
 }
 
 /* selector field title */

--- a/django_admin_bootstrapped/static/admin/css/overrides.css
+++ b/django_admin_bootstrapped/static/admin/css/overrides.css
@@ -172,3 +172,13 @@ td.action-checkbox {
     margin-bottom: 20px;
     clear: both;
 }
+
+p.file-upload {
+    line-height: 29px;
+    margin: 1;
+    padding: 1;
+    color: #666;
+    font-size: inherit;
+    font-weight: inherit;
+    font-family: inherit;
+}

--- a/django_admin_bootstrapped/static/admin/css/overrides.css
+++ b/django_admin_bootstrapped/static/admin/css/overrides.css
@@ -44,9 +44,7 @@ a:focus {
 .selector .selector-filter label {
     display: none;
 }
-.selector h2 {
 
-}
 .selector select {
     height: 17.2em;
     width: 100%; /* fix offscreen scroll-bar on selector-chosen */

--- a/django_admin_bootstrapped/static/admin/css/overrides.css
+++ b/django_admin_bootstrapped/static/admin/css/overrides.css
@@ -45,9 +45,7 @@ a:focus {
     display: none;
 }
 .selector h2 {
-    font-size: 100%;
-    margin: 0;
-    padding: 6px;
+
 }
 .selector select {
     height: 17.2em;
@@ -72,8 +70,8 @@ a:focus {
     background-color: #FFF;
     background-image: none;
     border: 1px solid #CCC;
-    border-radius: 4px;
-    box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.075) inset;
+    border-radius: 0px 0px 4px 4px;
+    box-shadow: 0px 0px 1px rgba(0, 0, 0, 0.075) inset;
     transition: border-color 0.15s ease-in-out 0s, box-shadow 0.15s ease-in-out 0s;
 }
 
@@ -88,14 +86,23 @@ a:focus {
 /* selector field title */
 .selector > .selector-available > h2, .selector > .selector-chosen > h2 {
     text-align: left;
-    background: white;
+    background: rgba(211, 211, 211, 0.2);
     color: #666;
-    border: 0px solid #ccc;
+    border-top: 1px solid #ccc;
+    border-left: 1px solid #ccc;
+    border-right: 1px solid #ccc;
+    border-bottom: 0px solid #ccc;
+    font-size: 100%;
+    font-weight: 600;
+    margin: 0px;
+    padding: 10px 0px 6px 10px;
+    height: 36px;
+    border-radius: 4px 4px 0px 0px;
 }
 
 /* selector filter box bootstrapping */
 .selector .selector-available input {
-    width: 100%;
+    width: 80%;
     height: 34px;
     padding: 6px 12px;
     font-size: 14px;
@@ -107,6 +114,13 @@ a:focus {
     border-radius: 4px;
     box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.075) inset;
     transition: border-color 0.15s ease-in-out 0s, box-shadow 0.15s ease-in-out 0s;
+}
+
+.selector .selector-available p {
+    background: rgba(211, 211, 211, 0.2);
+    border-left: 1px solid #ccc;
+    border-right: 1px solid #ccc;
+    padding: 0px 0px 7px 6px;
 }
 
 /* selector chooseall and clearall button spacing */

--- a/django_admin_bootstrapped/static/admin/css/overrides.css
+++ b/django_admin_bootstrapped/static/admin/css/overrides.css
@@ -32,6 +32,9 @@ a:focus {
     float: none;
 }
 
+
+/* SELECTOR (FILTER INTERFACE) */
+
 .selector .selector-filter {
     border: 0px solid #ccc;
     border-width: 0 0px;

--- a/django_admin_bootstrapped/static/admin/css/overrides.css
+++ b/django_admin_bootstrapped/static/admin/css/overrides.css
@@ -32,6 +32,12 @@ a:focus {
     float: none;
 }
 
+.selector .selector-filter {
+    border: 0px solid #ccc;
+    border-width: 0 0px;
+    padding: 4px 0px 4px 0px;
+}
+
 .selector .selector-filter label {
     display: none;
 }
@@ -42,10 +48,81 @@ a:focus {
 }
 .selector select {
     height: 17.2em;
+    width: 100%; /* fix offscreen scroll-bar on selector-chosen */
     border: 1px #ccc solid;
 }
+
 .selector .selector-chosen select {
     border-top: 0;
+}
+
+/* fix offscreen scroll-bar on selector-chosen */
+.selector-available, .selector-chosen {
+    width: 47%;
+}
+
+/* selector object list */
+.selector > .selector-available > select, .selector > .selector-chosen > select {
+    font-size: 14px;
+    line-height: 1.42857;
+    color: #555;
+    background-color: #FFF;
+    background-image: none;
+    border: 1px solid #CCC;
+    border-radius: 4px;
+    box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.075) inset;
+    transition: border-color 0.15s ease-in-out 0s, box-shadow 0.15s ease-in-out 0s;
+}
+
+
+/* can't resize selector-chosen height, so we'll just move it down to match selector-available*/
+.selector > .selector-chosen > select {
+    margin-top: 13px;
+}
+
+/* selector object list items */
+.selector > .selector-available > select > option, .selector > .selector-chosen > select > option {
+    padding: 6px;
+    border-bottom-width: 1px;
+    border-bottom-color: lightgray;
+    border-bottom-style: groove
+}
+
+/* selector field title */
+.selector > .selector-available > h2, .selector > .selector-chosen > h2 {
+    text-align: left;
+    background: white;
+    color: #666;
+    border: 0px solid #ccc;
+}
+
+/* selector filter box bootstrapping */
+.selector .selector-available input {
+    width: 100%;
+    height: 34px;
+    padding: 6px 12px;
+    font-size: 14px;
+    line-height: 1.42857;
+    color: #555;
+    background-color: #FFF;
+    background-image: none;
+    border: 1px solid #CCC;
+    border-radius: 4px;
+    box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.075) inset;
+    transition: border-color 0.15s ease-in-out 0s, box-shadow 0.15s ease-in-out 0s;
+}
+
+/* selector chooseall and clearall button spacing */
+a.selector-chooseall {
+    padding: 0px 20px 3px 0;
+}
+a.selector-clearall {
+    padding: 0px 0 3px 20px;
+}
+
+/* italicize help text */
+span.help-block {
+    font-style: italic
 }
 
 .checkbox{


### PR DESCRIPTION
Some CSS edits to pull the filter-horizontal and file-upload widgets kicking and screaming into the world of bootstrap. Still far from perfect, but I think they're better than they were.

Before:
![example-before](https://cloud.githubusercontent.com/assets/7026330/8390517/9fc55464-1c66-11e5-9314-56a0670c9052.PNG)

After:
![example-after](https://cloud.githubusercontent.com/assets/7026330/8390519/a49246be-1c66-11e5-9afe-aaceafe23569.PNG)

Thoughts? Happy to make further edits.
