### PR TITLE
Make change_password look more like the standard change_form

### DIFF
--- a/django_admin_bootstrapped/templates/admin/auth/user/change_password.html
+++ b/django_admin_bootstrapped/templates/admin/auth/user/change_password.html
@@ -19,7 +19,7 @@
 {% endblock %}
 {% endif %}
 {% block content %}<div id="content-main">
-<form action="{{ form_url }}" method="post" id="{{ opts.model_name }}_form">{% csrf_token %}{% block form_top %}{% endblock %}
+<form class="form-horizontal" action="{{ form_url }}" method="post" id="{{ opts.model_name }}_form">{% csrf_token %}{% block form_top %}{% endblock %}
 <div>
 {% if is_popup %}<input type="hidden" name="_popup" value="1" />{% endif %}
 {% if form.errors %}
@@ -39,10 +39,12 @@
 <div class="col-md-12 form-group">
   {{ form.password1.errors }}
   <div class="control-label col-md-3">{{ form.password1.label_tag }}</div>
-  <div class="controls col-md-9">{% dab_field_rendering form.password1 %}</div>
-  {% if form.password1.help_text %}
-  <span class="help-block">{{ form.password1.help_text }}</span>
-  {% endif %}
+  <div class="controls col-md-9">
+    {% dab_field_rendering form.password1 %}
+    {% if form.password1.help_text %}
+    <span class="help-block">{{ form.password1.help_text }}</span>
+    {% endif %}
+  </div>
 </div>
 </div>
 </div>
@@ -52,10 +54,12 @@
 <div class="col-md-12 form-group">
   {{ form.password2.errors }}
   <div class="control-label col-md-3">{{ form.password2.label_tag }}</div>
-  <div class="controls col-md-9">{% dab_field_rendering form.password2 %}</div>
-  {% if form.password2.help_text %}
-  <span class="help-block">{{ form.password2.help_text }}</span>
-  {% endif %}
+  <div class="controls col-md-9">
+    {% dab_field_rendering form.password2 %}
+    {% if form.password2.help_text %}
+    <span class="help-block">{{ form.password2.help_text }}</span>
+    {% endif %}
+  </div>
 </div>
 </div>
 </div>


### PR DESCRIPTION
A few minor changes on top of 3b53c83feebc949ec318c869ef8c85956648bfdb; thanks for doing that. I added form-horizontal for right-justified field labels and pulled help blocks into the same div as edit controls so they're aligned together.
