### PR TITLE
Fix data-admin-url model lookup for Django 1.8 ContentType

### DIFF
--- a/django_admin_bootstrapped/widgets.py
+++ b/django_admin_bootstrapped/widgets.py
@@ -24,7 +24,7 @@ class GenericContentTypeSelect(Select):
             extra_attrs = {
                 'data-generic-lookup-enabled': 'yes',
                 'data-admin-url': silent_reverse('admin:{0.app_label}_' \
-                                             '{0.name}_changelist'.format(ct)),
+                                             '{0.model}_changelist'.format(ct)),
             }
 
         if option_value in selected_choices:


### PR DESCRIPTION
Django 1.8 ContentType has changed the behaviour of "name" and so in some cases the previous version no longer returns a valid URL. The correct parameter to use for the Model name is the "model" parameter of the ContentType object.