### PR TITLE
Fix duplicate error messages in tabular inlines

### DIFF
--- a/django_admin_bootstrapped/templates/admin/edit_inline/tabular.html
+++ b/django_admin_bootstrapped/templates/admin/edit_inline/tabular.html
@@ -10,7 +10,6 @@
    </div>
    {% endif %}
 
-   {{ inline_admin_formset.formset.non_form_errors }}
    <table class="table table-striped table-bordered">
      <thead><tr>
      {% for field in inline_admin_formset.fields %}


### PR DESCRIPTION
If an admin's tabular inlines had errors, then the error block was shown twice. (Notice a few lines above where I deleted the line.)