### PR TITLE
Added a hidden Save button, to change the default Enter action

### DIFF
--- a/django_admin_bootstrapped/templates/admin/submit_line.html
+++ b/django_admin_bootstrapped/templates/admin/submit_line.html
@@ -6,6 +6,9 @@
     {% endif %}
 </div>
 <div class="pull-right">
+<!--Add a hidden submit button to set the default action on press of the Enter key-->
+<div style="display:none;"><input type="submit" value="{% trans 'Save' %}" name="_save"/></div>
+<!-- -->
 {% if show_save_as_new %}<input type="submit" value="{% trans 'Save as new' %}" class="btn btn-default" name="_saveasnew" {{ onclick_attrib }}/>{% endif %}
 {% if show_save_and_add_another %}<input type="submit" value="{% trans 'Save and add another' %}" class="btn btn-default" name="_addanother" {{ onclick_attrib }} />{% endif %}
 {% if show_save_and_continue %}<input type="submit" value="{% trans 'Save and continue editing' %}" class="btn btn-default" name="_continue" {{ onclick_attrib }}/>{% endif %}


### PR DESCRIPTION
Since pressing Enter while in a text field of an HTML form submits via the first submit button, adding a hidden one will cause it to be used instead of the first visible one. Result: Enter saves the form without hitting the Save as New button.