### PR TITLE
Fix an uncaught exception in form_fieldset_column_width templatetag

### DIFF
--- a/django_admin_bootstrapped/templatetags/bootstrapped_goodies_tags.py
+++ b/django_admin_bootstrapped/templatetags/bootstrapped_goodies_tags.py
@@ -51,7 +51,11 @@ def column_width(value):
 @register.filter(name='form_fieldset_column_width')
 def form_fieldset_column_width(form):
     def max_line(fieldset):
-        return max([len(list(line)) for line in fieldset])
+        try:
+            return max([len(list(line)) for line in fieldset])
+        # This ValueError is for case that fieldset has no line.
+        except ValueError:
+            return 0
 
     try:
         width = max([max_line(fieldset) for fieldset in form])


### PR DESCRIPTION
**Fore Sure Part:**

Fix an uncaught exception in `form_fieldset_column_width` templatetag that will cause the admin won't allow `fieldsets` display multiple fields on the same line in some rare situation(for example empty `fields` value for `fieldset`).

For example consider following example of `fieldsets` attr of a `ModelAdmin`:
```python
fieldsets = (
    (None, {'fields': ('username', 'password')}),
    ('Empty section', {'fields': ()}),
)
```
While this is indeed a very rare situation but it's considered valid in Django Admin.

In this case the `max_line` will prematurely throw an Exception and resulting `form_fieldset_column_width` returns `12` regardless of the values from other fieldsets.

**Debatable Part:**

And after reading the code a little more I found that code in `change_form.html` will make every field in the admin page short if there's any "multi field on one line" situation, which is not default Django admin behavior. Thus I changed the filter in `change_form.html`.

I notice that this line is the only part in code that used `form_fieldset_column_width` templatetag so this is probably an intended behavior but I don't really buy this behavior, please let me know  your idea.