### PR TITLE
Fix bug if jQuery.noConflict() used

### DIFF
--- a/django_admin_bootstrapped/templates/admin/login.html
+++ b/django_admin_bootstrapped/templates/admin/login.html
@@ -85,9 +85,11 @@
 </form>
 
 <script type="text/javascript">
-$(document).ready(function() {
-  $('#id_username').attr('autocapitalize', 'off').focus();
-})
+(function($) {
+  $(document).ready(function() {
+    $('#id_username').attr('autocapitalize', 'off').focus();
+  });
+})(jQuery);
 </script>
 </div>
 {% endblock %}


### PR DESCRIPTION
Fixes #234 

It looks like the reason this was handled differently to the other jquery dependent scripts is that `django.jQuery` is not defined on the login page (but `jQuery` still should be assuming that it has actually been included).