### PR TITLE
Correctly mark the required and optional fields in admin form.

### DIFF
--- a/django_admin_bootstrapped/static/admin/css/overrides.css
+++ b/django_admin_bootstrapped/static/admin/css/overrides.css
@@ -264,3 +264,14 @@ p.file-upload > input[type="file"] {
   background-color: #337ab7;
   border-color: #337ab7;
 }
+
+
+/* Standard and required fields on admin form. */
+label {
+  font-weight: normal;
+}
+
+label.required {
+  font-weight: 800;
+}
+


### PR DESCRIPTION
In the admin form is not required fields are displayed as bold  - this is not right! 
Required fields: font-weight: 800;
Optional fields: font-weight: normal;