### PR TITLE
Update missing `alert-` prefix in messages

### DIFF
--- a/django_admin_bootstrapped/templates/admin/base.html
+++ b/django_admin_bootstrapped/templates/admin/base.html
@@ -166,7 +166,7 @@
         <div class="row">
             <div class="col-sm-12">
                 {% for message in messages %}
-                <div class="alert {{ message.tags|default:"alert-info" }}">
+                <div class="alert alert-{{ message.tags|default:"info" }}">
                     {{ message|capfirst }}
                 </div>
                 {% endfor %}


### PR DESCRIPTION
Without the 'alert-' prefix, the message (eg: "Successfully deleted 2 books") is partially unstyled, having no colour.