### PR TITLE
Fix duplicated fieldset ids when we have multiple StackedInlines

### DIFF
--- a/django_admin_bootstrapped/templates/admin/edit_inline/stacked.html
+++ b/django_admin_bootstrapped/templates/admin/edit_inline/stacked.html
@@ -42,10 +42,12 @@
                 {{ inline_admin_form.form.non_field_errors }}
               </div>
           {% endif %}
-          {% with stacked_prefix=forloop.counter %}
+          {% with forloop.counter|stringformat:"s" as counter %}
+          {% with inline_admin_formset.formset.prefix|add:"-"|add:counter as stacked_prefix %}
           {% for fieldset in inline_admin_form %}
             {% include "admin/includes/fieldset.html" with group_column_width=fieldset|fieldset_column_width %}
           {% endfor %}
+          {% endwith %}
           {% endwith %}
           {% if inline_admin_form.needs_explicit_pk_field %}{{ inline_admin_form.pk_field.field }}{% endif %}
           {{ inline_admin_form.fk_field.field }}

--- a/test_django_admin_bootstrapped/test_django_admin_bootstrapped/admin.py
+++ b/test_django_admin_bootstrapped/test_django_admin_bootstrapped/admin.py
@@ -19,6 +19,15 @@ class TestThatStackedFieldsetInline(admin.StackedInline):
         }),
     )
 
+class TestAnotherStackedFieldsetInline(admin.StackedInline):
+    model = TestThat
+    fieldsets = (
+        ('A collapsed fieldset', {
+            'classes': ('collapse',),
+            'fields': ['test_ip', 'test_url', 'test_date',]
+        }),
+    )
+
 class TestThatTabularInline(admin.TabularInline):
     model = TestThat
 
@@ -51,7 +60,7 @@ class TestMeAdmin(admin.ModelAdmin):
 
 class TestMeAdminFieldsets(TestMeAdmin):
     actions_on_bottom = True
-    inlines= [TestThatStackedFieldsetInline]
+    inlines= [TestThatStackedFieldsetInline, TestAnotherStackedFieldsetInline]
     fieldsets = (
         ('A fieldset', {
             'fields': ['test_m2m', 'test_ip', 'test_url', 'test_int', 'test_img', 'test_file', 'test_date', 'test_char', 'test_bool', 'test_time', 'test_slug', 'test_text', ],


### PR DESCRIPTION
the fieldset id format was: `fieldset-{inline-instance-index}-{fieldset-index}`
changed to: `fieldset-{formset-prefix}-{inline-instance-index}-{fieldset-index}`