### PR TITLE
Message box css

### DIFF
--- a/django_admin_bootstrapped/templates/admin/base.html
+++ b/django_admin_bootstrapped/templates/admin/base.html
@@ -166,7 +166,7 @@
         <div class="row">
             <div class="col-sm-12">
                 {% for message in messages %}
-                <div class="alert {{ message.tags|default:"alert-info" }}">
+                <div class="alert alert-{{ message.tags|default:"alert-info" }}">
                     {{ message|capfirst }}
                 </div>
                 {% endfor %}

--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,7 @@ CLASSIFIERS = [
 
 setup(
     author="Riccardo Forina",
-    author_email="riccardo@forina.me",
-    maintainer="Riccardo Magliocchetti",
-    maintainer_email="riccardo.magliocchetti@gmail.com",
+    # maintainer="Riccardo Magliocchetti",
     name='django-admin-bootstrapped',
     version='2.5.7',
     description='A Bootstrap theme for Django Admin',
@@ -31,7 +29,7 @@ setup(
     classifiers=CLASSIFIERS,
     install_requires=[
         'setuptools',
-        'Django>=1.8,<1.9',
+        'Django>=1.8', # ,<1.9
     ],
     test_suite='django_admin_bootstrapped.runtests.runtests',
     packages=find_packages(),


### PR DESCRIPTION
1. Seems to work fine with Django 1.9+.
2. Fixed a problem with the message having the wrong css class ('success' instead of 'alert-success').