### PR TITLE
add inlines errorlist css

### DIFF
--- a/django_admin_bootstrapped/static/admin/css/overrides.css
+++ b/django_admin_bootstrapped/static/admin/css/overrides.css
@@ -264,3 +264,7 @@ p.file-upload > input[type="file"] {
   background-color: #337ab7;
   border-color: #337ab7;
 }
+
+.errorlist {
+    color: #a94442;
+}


### PR DESCRIPTION
There is no error style  in stacked.html .

`{% if inline_admin_form.form.non_field_errors %}{{ inline_admin_form.form.non_field_errors }}{% endif %}`